### PR TITLE
Fix error when using "ReplyTo Email Field" property 

### DIFF
--- a/classes/Mails/Notification.php
+++ b/classes/Mails/Notification.php
@@ -71,7 +71,7 @@ class Notification implements Mailable
 
             // ADD REPLY TO ADDRESS
             if (!empty($this->properties['mail_replyto'])) {
-                $message->replyTo($this->properties['mail_replyto']);
+                $message->replyTo($this->post[$this->properties["mail_replyto"]]);
             }
 
             // ADD UPLOADS

--- a/classes/Mails/Notification.php
+++ b/classes/Mails/Notification.php
@@ -71,7 +71,7 @@ class Notification implements Mailable
 
             // ADD REPLY TO ADDRESS
             if (!empty($this->properties['mail_replyto'])) {
-                $message->replyTo($this->post[$this->properties["mail_replyto"]]);
+                $message->replyTo($this->post[$this->properties['mail_replyto']]);
             }
 
             // ADD UPLOADS


### PR DESCRIPTION
This fixes the "Address in mailbox given [email] does not comply with RFC 2822, 3.6.2. on line 355 of \vendor\swiftmailer\swiftmailer\lib\classes\Swift\Mime\Headers\MailboxHeader.php" error when using the "ReplyTo Email Field" property.