### PR TITLE
convert recaptcha to vanilla js

### DIFF
--- a/assets/js/recaptcha.js
+++ b/assets/js/recaptcha.js
@@ -1,8 +1,8 @@
 var captchas = [];
 
 var onloadCallback = function() {
-    jQuery('.g-recaptcha').each(function(index, el) {
-        captchas[el.id] = grecaptcha.render(el, $(el).data());
+    document.querySelectorAll('.g-recaptcha').forEach(function(el) {
+        captchas[el.id] = grecaptcha.render(el, el.dataset.id);
     });
 }
 


### PR DESCRIPTION
Winter 1.1.8 dropped its dependence on jQuery with the new snowboard framework.
(ref. https://wintercms.com/docs/snowboard/migration-guide#no-jquery)

This PR updates the recaptcha.js to use vanilla JS instead of jQuery.