### PR TITLE
Convert jquery js code to vanilla js

### DIFF
--- a/assets/js/inline-errors.js
+++ b/assets/js/inline-errors.js
@@ -1,7 +1,11 @@
-$(window).on('ajaxInvalidField', function(event, fieldElement, fieldName, errorMsg, isFirst) {
-    $(fieldElement).closest('.form-group').addClass('has-error');
-});
+window.addEventListener('ajaxInvalidField', function(event, fieldElement, fieldName, errorMsg, isFirst) {
+    fieldElement.closest('.form-group').classList.add('has-error')
+})
 
-$(document).on('ajaxPromise', '[data-request]', function() {
-    $(this).closest('form').find('.form-group.has-error').removeClass('has-error');
-});
+document.querySelectorAll('[data-request]').forEach(function(el) {
+    el.addEventListener('ajaxPromise', function(event, promise) {
+        el.closest('form').querySelectorAll('.form-group.has-error').forEach(function(errorElement) {
+            errorElement.classList.remove('has-error')
+        })
+    })
+})

--- a/components/partials/js/reset-form.htm
+++ b/components/partials/js/reset-form.htm
@@ -1,1 +1,1 @@
-$('{{ id }}').parents('form')[0].reset();
+document.querySelector('{{ id }}').closest('form').reset()


### PR DESCRIPTION
Winter 1.1.8 dropped its dependence on jQuery with the new snowboard framework.

This PR updates the inline-error.js to use vanilla JS instead of jQuery.

Note: needs testing.

TODO: convert js code in `components/partials/filepond.htm`