### PR TITLE
Get the value for the provided form field name

### DIFF
--- a/classes/Mails/Notification.php
+++ b/classes/Mails/Notification.php
@@ -71,7 +71,7 @@ class Notification implements Mailable
 
             // ADD REPLY TO ADDRESS
             if (!empty($this->properties['mail_replyto'])) {
-                $message->replyTo($this->properties['mail_replyto']);
+                $message->replyTo($this->post[$this->properties['mail_replyto']]);
             }
 
             // ADD UPLOADS


### PR DESCRIPTION
Only the form field name for which to send the reply to is currently used. We need to retrieve the ***value*** of that field from the post data. 